### PR TITLE
Feature: add support for --soft-fail flag

### DIFF
--- a/docs/usage/command_line_mode.md
+++ b/docs/usage/command_line_mode.md
@@ -39,6 +39,7 @@ Flags:
   -l, --log-level string     log level (debug, info, warn, error, panic, fatal) (default "info")
   -x, --log-type string      log output type (console, json) (default "console")
   -o, --output string        output type (human, json, yaml, xml) (default "human")
+  -s, --soft-fail            exits checks with status code 0
 
 Use "terrascan [command] --help" for more information about a command.
 ```
@@ -287,6 +288,7 @@ aws_ecr_repository:
 | -l | Use this to specify what log settings | debug, **info**, warn, error, panic, fatal  |
 | -x | Use this to specify the log file format | **console**, json |
 | -o | Use this to specify the scan output type | **human**, json, yaml, xml, junit-xml, sarif, github-sarif |
+| -s | Use this to exit checks with status code 0 | true, false |
 
 
 

--- a/pkg/cli/register.go
+++ b/pkg/cli/register.go
@@ -39,7 +39,7 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&LogType, "log-type", "x", "console", "log output type (console, json)")
 	rootCmd.PersistentFlags().StringVarP(&OutputType, "output", "o", "human", "output type (human, json, yaml, xml, junit-xml, sarif, github-sarif)")
 	rootCmd.PersistentFlags().StringVarP(&ConfigFile, "config-path", "c", "", "config file path")
-
+	rootCmd.PersistentFlags().BoolVarP(&SoftFail, "soft-fail", "s", false, "exits checks with status code 0")
 	// Function to execute before processing commands
 	cobra.OnInitialize(func() {
 		// Set up the logger
@@ -77,6 +77,9 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
+		if SoftFail {
+			os.Exit(0)
+		}
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -32,6 +32,9 @@ var (
 
 	// ConfigFile Config file path
 	ConfigFile string
+
+	// SoftFail option allows you to exit checks with 0 status.
+	SoftFail bool
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -256,6 +256,12 @@ func (s ScanOptions) writeResults(results runtime.Output) error {
 
 // getExitCode returns appropriate exit code for terrascan based on scan output
 func getExitCode(o runtime.Output) int {
+
+	// if SoftFail is set to true then we return 0 for any policy violation errors
+	if SoftFail {
+		return 0
+	}
+
 	if len(o.Violations.ViolationStore.DirScanErrors) > 0 {
 		if o.Violations.ViolationStore.Summary.ViolatedPolicies > 0 {
 			return 5

--- a/test/e2e/scan/scan_test.go
+++ b/test/e2e/scan/scan_test.go
@@ -295,4 +295,25 @@ var _ = Describe("Scan", func() {
 			})
 		})
 	})
+
+	Describe("scan is run with --soft-fail flag", func() {
+		Context("no tf files are present in the working directory", func() {
+			It("scans the directory with all iac and display results with exit code 0", func() {
+				scanArgs := []string{scanUtils.ScanCommand, "--soft-fail"}
+				session = helper.RunCommand(terrascanBinaryPath, outWriter, errWriter, scanArgs...)
+				helper.ValidateExitCode(session, scanUtils.ScanTimeout, helper.ExitCodeZero)
+			})
+
+		})
+		Context("tf files are present in the working directory", func() {
+			It("should scan the directory, return results and exit with status code 0", func() {
+				workDir, err := filepath.Abs(filepath.Join(awsIacRelPath, "aws_ami_violation"))
+				Expect(err).NotTo(HaveOccurred())
+
+				scanArgs := []string{scanUtils.ScanCommand, "--soft-fail", "-i", "terraform", "--non-recursive"}
+				session = helper.RunCommandDir(terrascanBinaryPath, workDir, outWriter, errWriter, scanArgs...)
+				Eventually(session, scanUtils.ScanTimeout).Should(gexec.Exit(helper.ExitCodeZero))
+			})
+		})
+	})
 })


### PR DESCRIPTION

## Description
This PR adds support for `--soft-fail` flag at the top level. I have implemented this similar to how `tfsec` has - as requested in the issue #981. Basically Error codes are suppressed for checks i.e. exit code will be 0 and any kind of unexpected error would still fail with exit code 1. 

## Issue
Fixes https://github.com/accurics/terrascan/issues/981


## How to run
```
terrascan scan --soft-fail
```

I have added 2 integration tests for validation