### PR TITLE
Update object.get first parameter

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_cloudtrail/cloudTrailMultiRegion.rego
+++ b/pkg/policies/opa/rego/aws/aws_cloudtrail/cloudTrailMultiRegion.rego
@@ -2,5 +2,5 @@ package accurics
 
 {{.prefix}}cloudTrailMultiRegionEnabled[cloud_trail.id]{
     cloud_trail = input.aws_cloudtrail[_]
-    object.get(cloud_trail, "is_multi_region_trail", "undefined") == "undefined"
+    object.get(cloud_trail.config, "is_multi_region_trail", "undefined") == "undefined"
 }


### PR DESCRIPTION
the first parameter of the object.get function updated with value cloud_trail.config
fix proposed in issue: False positive for cloudTrailMultiRegionEnabled (AC_AWS_0448) #1432