### PR TITLE
bugfix: provider version coming as 0.0.0 or empty

### DIFF
--- a/pkg/iac-providers/terraform/commons/load-dir.go
+++ b/pkg/iac-providers/terraform/commons/load-dir.go
@@ -158,9 +158,6 @@ func (t TerraformDirectoryLoader) loadDirRecursive(dirList []string) (output.All
 			t.addError(errMessage, dir)
 		}
 
-		// getting provider version for the root module
-		providerVersion := GetModuleProviderVersion(rootMod)
-
 		// get unified config for the current directory
 		unified, diags := t.buildUnifiedConfig(rootMod, dir)
 		// Get the downloader chache
@@ -209,12 +206,7 @@ func (t TerraformDirectoryLoader) loadDirRecursive(dirList []string) (output.All
 				}
 
 				resourceConfig.TerraformVersion = t.terraformVersion
-				resourceConfig.ProviderVersion = providerVersion
-
-				// if root module do not have provider contraints fetch the latest compatible version
-				if resourceConfig.ProviderVersion == "" {
-					resourceConfig.ProviderVersion = LatestProviderVersion(managedResource.Provider, t.terraformVersion)
-				}
+				resourceConfig.ProviderVersion = GetModuleProviderVersion(current.Config.Module, managedResource.Provider, t.terraformVersion)
 				// set module name
 				resourceConfig.ModuleName = current.Name
 
@@ -295,9 +287,6 @@ func (t TerraformDirectoryLoader) loadDirNonRecursive() (output.AllResourceConfi
 		t.addError(errMessage, t.absRootDir)
 	}
 
-	// getting provider version for the root module
-	providerVersion := GetModuleProviderVersion(rootMod)
-
 	// get unified config for the current directory
 	unified, diags := t.buildUnifiedConfig(rootMod, t.absRootDir)
 
@@ -360,12 +349,7 @@ func (t TerraformDirectoryLoader) loadDirNonRecursive() (output.AllResourceConfi
 			}
 
 			resourceConfig.TerraformVersion = t.terraformVersion
-			resourceConfig.ProviderVersion = providerVersion
-
-			// if root module do not have provider contraints fetch the latest compatible version
-			if resourceConfig.ProviderVersion == "" {
-				resourceConfig.ProviderVersion = LatestProviderVersion(managedResource.Provider, t.terraformVersion)
-			}
+			resourceConfig.ProviderVersion = GetModuleProviderVersion(current.Config.Module, managedResource.Provider, t.terraformVersion)
 
 			if isRemoteModule {
 				resourceConfig.IsRemoteModule = &isRemoteModule

--- a/pkg/iac-providers/terraform/commons/load-file.go
+++ b/pkg/iac-providers/terraform/commons/load-file.go
@@ -42,13 +42,11 @@ func LoadIacFile(absFilePath, terraformVersion string) (allResourcesConfig outpu
 		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
 
-	if diags != nil {
+	if diags.HasErrors() {
 		errMessage := fmt.Sprintf("failed to load iac file '%s'. error:\n%v\n", absFilePath, getErrorMessagesFromDiagnostics(diags))
 		zap.S().Debug(errMessage)
 		return allResourcesConfig, fmt.Errorf(errMessage)
 	}
-	// getting provider version for the file
-	providerVersion := GetFileProviderVersion(hclFile)
 
 	// initialize normalized output
 	allResourcesConfig = make(map[string][]output.ResourceConfig)
@@ -62,20 +60,15 @@ func LoadIacFile(absFilePath, terraformVersion string) (allResourcesConfig outpu
 			return allResourcesConfig, fmt.Errorf("failed to create ResourceConfig")
 		}
 
+		resourceConfig.TerraformVersion = terraformVersion
+		managedResource.Provider = ResolveProvider(managedResource, hclFile.RequiredProviders)
+		resourceConfig.ProviderVersion = GetProviderVersion(hclFile, managedResource.Provider, terraformVersion)
 		// set module name
 		// module name for the file scan will always be root
 		resourceConfig.ModuleName = "root"
 
 		// extract file name from path
 		resourceConfig.Source = getFileName(resourceConfig.Source)
-
-		resourceConfig.TerraformVersion = terraformVersion
-		resourceConfig.ProviderVersion = providerVersion
-
-		// if root module do not have provider contraints fetch the latest compatible version
-		if resourceConfig.ProviderVersion == "" {
-			resourceConfig.ProviderVersion = LatestProviderVersion(managedResource.Provider, terraformVersion)
-		}
 
 		// append to normalized output
 		if _, present := allResourcesConfig[resourceConfig.Type]; !present {

--- a/pkg/iac-providers/terraform/commons/load-file_test.go
+++ b/pkg/iac-providers/terraform/commons/load-file_test.go
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2022 Tenable, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package commons
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tenable/terrascan/pkg/iac-providers/output"
+	"github.com/tenable/terrascan/pkg/iac-providers/terraform/commons/test"
+	"github.com/tenable/terrascan/pkg/utils"
+)
+
+func TestLoadIacFile(t *testing.T) {
+	type args struct {
+		absFilePath      string
+		terraformVersion string
+	}
+	tests := []struct {
+		name                   string
+		args                   args
+		outputJSON             string
+		wantAllResourcesConfig output.AllResourceConfigs
+		wantErr                bool
+	}{
+		{
+			name: "file with no provider defined",
+			args: args{
+				absFilePath:      filepath.Join(testDataDir, "terraform_iac_files", "with_no_provider.tf"),
+				terraformVersion: "0.15.0",
+			},
+			outputJSON: filepath.Join(testDataDir, "tfjson", "output_no_provider_defined.json"),
+		},
+		{
+			name: "file with provider config",
+			args: args{
+				absFilePath:      filepath.Join(testDataDir, "terraform_iac_files", "with_provider_config.tf"),
+				terraformVersion: "0.15.0",
+			},
+			outputJSON: filepath.Join(testDataDir, "tfjson", "output_with_provider_config.json"),
+		},
+		{
+			name: "file with required provider",
+			args: args{
+				absFilePath:      filepath.Join(testDataDir, "terraform_iac_files", "with_required_provider.tf"),
+				terraformVersion: "0.15.0",
+			},
+			outputJSON: filepath.Join(testDataDir, "tfjson", "output_with_required_provider.json"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadIacFile(tt.args.absFilePath, tt.args.terraformVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadIacFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			// if !reflect.DeepEqual(gotAllResourcesConfig, tt.wantAllResourcesConfig) {
+			// 	t.Errorf("LoadIacFile() = %v, want %v", gotAllResourcesConfig, tt.wantAllResourcesConfig)
+			// }
+
+			var want output.AllResourceConfigs
+
+			// Read the expected value and unmarshal into want
+			contents, _ := os.ReadFile(tt.outputJSON)
+			if utils.IsWindowsPlatform() {
+				contents = utils.ReplaceWinNewLineBytes(contents)
+			}
+
+			err = json.Unmarshal(contents, &want)
+			if err != nil {
+				t.Errorf("unexpected error unmarshalling want: %v", err)
+			}
+
+			match, err := test.IdenticalAllResourceConfigs(got, want)
+			if err != nil {
+				t.Errorf("unexpected error checking result: %v", err)
+			}
+			if !match {
+				g, _ := json.MarshalIndent(got, "", "  ")
+				w, _ := json.MarshalIndent(want, "", "  ")
+				t.Errorf("got '%v', want: '%v'", string(g), string(w))
+			}
+		})
+	}
+}

--- a/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_no_provider.tf
+++ b/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_no_provider.tf
@@ -1,0 +1,37 @@
+resource "aws_ecs_task_definition" "demo-ecs-task-definition" {
+  family                   = "ecs-task-definition-demo"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  execution_role_arn       = "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+  container_definitions    =  <<TASK_DEFINITION
+[
+    {
+        "cpu": 10,
+        "command": ["sleep", "10"],
+        "entryPoint": ["/"],
+        "environment": [
+            {"name": "VARNAME", "value": "VARVAL"}
+        ],
+        "essential": true,
+        "image": "jenkins",
+        "memory": 128,
+        "name": "jenkins",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 8080
+            }
+        ],
+        "resourceRequirements":[
+            {
+                "type":"InferenceAccelerator",
+                "value":"device_1"
+            }
+        ]
+    }
+]
+TASK_DEFINITION
+
+}

--- a/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_provider_config.tf
+++ b/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_provider_config.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "us-west-2"
+  version = "3.0.5"
+}
+
+resource "aws_ecs_task_definition" "demo-ecs-task-definition" {
+  family                   = "ecs-task-definition-demo"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  execution_role_arn       = "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+  container_definitions    =  <<TASK_DEFINITION
+[
+    {
+        "cpu": 10,
+        "command": ["sleep", "10"],
+        "entryPoint": ["/"],
+        "environment": [
+            {"name": "VARNAME", "value": "VARVAL"}
+        ],
+        "essential": true,
+        "image": "jenkins",
+        "memory": 128,
+        "name": "jenkins",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 8080
+            }
+        ],
+        "resourceRequirements":[
+            {
+                "type":"InferenceAccelerator",
+                "value":"device_1"
+            }
+        ]
+    }
+]
+TASK_DEFINITION
+
+}

--- a/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_required_provider.tf
+++ b/pkg/iac-providers/terraform/commons/testdata/terraform_iac_files/with_required_provider.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 4.4"
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "demo-ecs-task-definition" {
+  family                   = "ecs-task-definition-demo"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  memory                   = "1024"
+  cpu                      = "512"
+  execution_role_arn       = "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+  container_definitions    =  <<TASK_DEFINITION
+[
+    {
+        "cpu": 10,
+        "command": ["sleep", "10"],
+        "entryPoint": ["/"],
+        "environment": [
+            {"name": "VARNAME", "value": "VARVAL"}
+        ],
+        "essential": true,
+        "image": "jenkins",
+        "memory": 128,
+        "name": "jenkins",
+        "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 8080
+            }
+        ],
+        "resourceRequirements":[
+            {
+                "type":"InferenceAccelerator",
+                "value":"device_1"
+            }
+        ]
+    }
+]
+TASK_DEFINITION
+
+}

--- a/pkg/iac-providers/terraform/commons/testdata/tfjson/output_no_provider_defined.json
+++ b/pkg/iac-providers/terraform/commons/testdata/tfjson/output_no_provider_defined.json
@@ -1,0 +1,44 @@
+{
+    "aws_ecs_task_definition": [
+        {
+            "id": "aws_ecs_task_definition.demo-ecs-task-definition",
+            "name": "demo-ecs-task-definition",
+            "module_name": "root",
+            "source": "with_no_provider.tf",
+            "line": 1,
+            "type": "aws_ecs_task_definition",
+            "config": {
+                "container_definitions": "[\n    {\n        \"cpu\": 10,\n        \"command\": [\"sleep\", \"10\"],\n        \"entryPoint\": [\"/\"],\n        \"environment\": [\n            {\"name\": \"VARNAME\", \"value\": \"VARVAL\"}\n        ],\n        \"essential\": true,\n        \"image\": \"jenkins\",\n        \"memory\": 128,\n        \"name\": \"jenkins\",\n        \"portMappings\": [\n            {\n                \"containerPort\": 80,\n                \"hostPort\": 8080\n            }\n        ],\n        \"resourceRequirements\":[\n            {\n                \"type\":\"InferenceAccelerator\",\n                \"value\":\"device_1\"\n            }\n        ]\n    }\n]\n",
+                "cpu": "512",
+                "execution_role_arn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+                "family": "ecs-task-definition-demo",
+                "memory": "1024",
+                "network_mode": "awsvpc",
+                "requires_compatibilities": [
+                    "FARGATE"
+                ]
+            },
+            "line_config": {
+                "container_definitions": 9,
+                "cpu": 6,
+                "execution_role_arn": 7,
+                "family": 2,
+                "memory": 5,
+                "network_mode": 3,
+                "requires_compatibilities": 4
+            },
+            "skip_rules": null,
+            "max_severity": "",
+            "min_severity": "",
+            "container_images": [
+                {
+                    "name": "jenkins",
+                    "image": "jenkins",
+                    "vulnerabilities": null
+                }
+            ],
+            "terraform_version": "0.15.0",
+            "provider_version": "4.61.0"
+        }
+    ]
+}

--- a/pkg/iac-providers/terraform/commons/testdata/tfjson/output_with_provider_config.json
+++ b/pkg/iac-providers/terraform/commons/testdata/tfjson/output_with_provider_config.json
@@ -1,0 +1,44 @@
+{
+    "aws_ecs_task_definition": [
+        {
+            "id": "aws_ecs_task_definition.demo-ecs-task-definition",
+            "name": "demo-ecs-task-definition",
+            "module_name": "root",
+            "source": "with_provider_config.tf",
+            "line": 6,
+            "type": "aws_ecs_task_definition",
+            "config": {
+                "container_definitions": "[\n    {\n        \"cpu\": 10,\n        \"command\": [\"sleep\", \"10\"],\n        \"entryPoint\": [\"/\"],\n        \"environment\": [\n            {\"name\": \"VARNAME\", \"value\": \"VARVAL\"}\n        ],\n        \"essential\": true,\n        \"image\": \"jenkins\",\n        \"memory\": 128,\n        \"name\": \"jenkins\",\n        \"portMappings\": [\n            {\n                \"containerPort\": 80,\n                \"hostPort\": 8080\n            }\n        ],\n        \"resourceRequirements\":[\n            {\n                \"type\":\"InferenceAccelerator\",\n                \"value\":\"device_1\"\n            }\n        ]\n    }\n]\n",
+                "cpu": "512",
+                "execution_role_arn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+                "family": "ecs-task-definition-demo",
+                "memory": "1024",
+                "network_mode": "awsvpc",
+                "requires_compatibilities": [
+                    "FARGATE"
+                ]
+            },
+            "line_config": {
+                "container_definitions": 14,
+                "cpu": 11,
+                "execution_role_arn": 12,
+                "family": 7,
+                "memory": 10,
+                "network_mode": 8,
+                "requires_compatibilities": 9
+            },
+            "skip_rules": null,
+            "max_severity": "",
+            "min_severity": "",
+            "container_images": [
+                {
+                    "name": "jenkins",
+                    "image": "jenkins",
+                    "vulnerabilities": null
+                }
+            ],
+            "terraform_version": "0.15.0",
+            "provider_version": "3.0.5"
+        }
+    ]
+}

--- a/pkg/iac-providers/terraform/commons/testdata/tfjson/output_with_required_provider.json
+++ b/pkg/iac-providers/terraform/commons/testdata/tfjson/output_with_required_provider.json
@@ -1,0 +1,44 @@
+{
+    "aws_ecs_task_definition": [
+        {
+            "id": "aws_ecs_task_definition.demo-ecs-task-definition",
+            "name": "demo-ecs-task-definition",
+            "module_name": "root",
+            "source": "with_required_provider.tf",
+            "line": 10,
+            "type": "aws_ecs_task_definition",
+            "config": {
+                "container_definitions": "[\n    {\n        \"cpu\": 10,\n        \"command\": [\"sleep\", \"10\"],\n        \"entryPoint\": [\"/\"],\n        \"environment\": [\n            {\"name\": \"VARNAME\", \"value\": \"VARVAL\"}\n        ],\n        \"essential\": true,\n        \"image\": \"jenkins\",\n        \"memory\": 128,\n        \"name\": \"jenkins\",\n        \"portMappings\": [\n            {\n                \"containerPort\": 80,\n                \"hostPort\": 8080\n            }\n        ],\n        \"resourceRequirements\":[\n            {\n                \"type\":\"InferenceAccelerator\",\n                \"value\":\"device_1\"\n            }\n        ]\n    }\n]\n",
+                "cpu": "512",
+                "execution_role_arn": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+                "family": "ecs-task-definition-demo",
+                "memory": "1024",
+                "network_mode": "awsvpc",
+                "requires_compatibilities": [
+                    "FARGATE"
+                ]
+            },
+            "line_config": {
+                "container_definitions": 18,
+                "cpu": 15,
+                "execution_role_arn": 16,
+                "family": 11,
+                "memory": 14,
+                "network_mode": 12,
+                "requires_compatibilities": 13
+            },
+            "skip_rules": null,
+            "max_severity": "",
+            "min_severity": "",
+            "container_images": [
+                {
+                    "name": "jenkins",
+                    "image": "jenkins",
+                    "vulnerabilities": null
+                }
+            ],
+            "terraform_version": "0.15.0",
+            "provider_version": "4.4.0"
+        }
+    ]
+}

--- a/pkg/iac-providers/terraform/v12/testdata/tfjson/config1.json
+++ b/pkg/iac-providers/terraform/v12/testdata/tfjson/config1.json
@@ -69,7 +69,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_internet_gateway": [
@@ -96,7 +96,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_key_pair": [
@@ -119,7 +119,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_route_table": [
@@ -158,7 +158,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_route_table_association": [
@@ -181,7 +181,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_security_group": [
@@ -260,7 +260,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_subnet": [
@@ -291,7 +291,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ],
   "aws_vpc": [
@@ -322,7 +322,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.12.0",
-      "provider_version": "0.0.0"
+      "provider_version": "3.37.0"
     }
   ]
 }

--- a/pkg/iac-providers/terraform/v14/testdata/tfjson/config1.json
+++ b/pkg/iac-providers/terraform/v14/testdata/tfjson/config1.json
@@ -69,7 +69,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_internet_gateway": [
@@ -96,7 +96,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_key_pair": [
@@ -119,7 +119,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_route_table": [
@@ -158,7 +158,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_route_table_association": [
@@ -181,7 +181,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_security_group": [
@@ -260,7 +260,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_subnet": [
@@ -291,7 +291,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_vpc": [
@@ -322,7 +322,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.14.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ]
 }

--- a/pkg/iac-providers/terraform/v15/testdata/tfjson/config1.json
+++ b/pkg/iac-providers/terraform/v15/testdata/tfjson/config1.json
@@ -69,7 +69,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_internet_gateway": [
@@ -96,7 +96,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_key_pair": [
@@ -119,7 +119,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_route_table": [
@@ -158,7 +158,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_route_table_association": [
@@ -181,7 +181,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_security_group": [
@@ -260,7 +260,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_subnet": [
@@ -291,7 +291,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ],
   "aws_vpc": [
@@ -322,7 +322,7 @@
       "max_severity": "",
       "min_severity": "",
       "terraform_version": "0.15.0",
-      "provider_version": "0.0.0"
+      "provider_version": "4.62.0"
     }
   ]
 }


### PR DESCRIPTION
This PR tends to fix a bug where the terraform provider version was coming as 0.0.0 or empty.