### PR TITLE
Releaser fixes for archives.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,13 @@ archives:
       {{- else }}{{ .Arch }}{{ end }} 
   # for windows it is good to have zip along with tar.gz    
   - id: win_zip
+    name_template: >-
+      {{ .Binary }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,21 +18,16 @@ builds:
       - goos: windows
         goarch: arm64
 archives:
-  - id: darwin
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - id: format_all_build_names
+    name_template: >-
+      {{ .Binary }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }} 
   # for windows it is good to have zip along with tar.gz    
   - id: win_zip
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-    replacements:
-      windows: Windows
-      386: i386
-      amd64: x86_64
     format_overrides:
       - goos: windows
         format: zip

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,14 +18,17 @@ builds:
       - goos: windows
         goarch: arm64
 archives:
-  - replacements:
+  - id: darwin
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
       386: i386
       amd64: x86_64
-  # for windows it is good to have zip along with tar.gz
+  # for windows it is good to have zip along with tar.gz    
   - id: win_zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     replacements:
       windows: Windows
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ archives:
   - id: format_all_build_names
     name_template: >-
       {{ .Binary }}_
-      {{ .Version }}_
+      {{- trimprefix .Version  "." }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -30,7 +30,7 @@ archives:
   - id: win_zip
     name_template: >-
       {{ .Binary }}_
-      {{ .Version }}_
+      {{- trimprefix .Version  "." }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesreplacements


```• loading config file                              file=.goreleaser.yml
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 21: field replacements not found in type config.Archive
  line 29: field replacements not found in type config.Archive
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.19.2/x64/goreleaser' failed with exit code 1```