### PR TITLE
AC_AWS_0472: change password_reuse_prevention from 0 to 1 

### DIFF
--- a/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Low.0539.json
+++ b/pkg/policies/opa/rego/aws/aws_iam_account_password_policy/AWS.Iam.IAM.Low.0539.json
@@ -7,7 +7,7 @@
         "name": "passwordReuseNotAllowed",
         "parameter": "password_reuse_prevention",
         "prefix": "",
-        "value": 0
+        "value": 1
     },
     "severity": "LOW",
     "description": "It is recommended that the password policy prevent the reuse of passwords.Preventing password reuse increases account resiliency against brute force login attempts",


### PR DESCRIPTION
Value of 0 means that the number of previous passwords that users are prevented from reusing is zero, effectively disabling password reuse.

This fixes issue [1602](https://github.com/tenable/terrascan/issues/1602).