### PR TITLE
exclude "scratch" from the default latest check #1613

### DIFF
--- a/pkg/policies/opa/rego/docker/docker_from/imageVersionnotusinglatest.rego
+++ b/pkg/policies/opa/rego/docker/docker_from/imageVersionnotusinglatest.rego
@@ -9,5 +9,6 @@ package accurics
 {{.prefix}}{{.name}}{{.suffix}}[dockerFrom.id]{
 	dockerFrom := input.docker_from[_]
     config := dockerFrom.config
+    config != "scratch"
     not contains(config, ":")
 }


### PR DESCRIPTION
By default, in a docker FROM statement, if no tag is specified, it is treated as the :latest tag. This is flagged by rule AC_DOCKER_0041, but the current rego implementation of the rule erroneously includes the case when the FROM references the special reserved 'image' - "scratch" - ref https://hub.docker.com/_/scratch  This PR ensures FROM scratch is not flagged.