### PR TITLE
Support newer format versions for terraform JSON plan

### DIFF
--- a/pkg/iac-providers/tfplan/v1/load-file.go
+++ b/pkg/iac-providers/tfplan/v1/load-file.go
@@ -35,7 +35,7 @@ var (
 )
 
 func getTfPlanFormatVersions() []string {
-	return []string{"0.1", "0.2"}
+	return []string{"0.1", "0.2", "1.0", "1.1", "1.2"}
 }
 
 // LoadIacFile parses the given tfplan file from the given file path


### PR DESCRIPTION
The format versions currently supported by Terrascan are very outdated (since Terraform 1.1.x). This PR adds support for the newer versions.
This was already tested and confirm not to break Terrascan functionality.