### PR TITLE
Fix the Dockerfile rules for cd and apt

### DIFF
--- a/pkg/policies/opa/rego/docker/docker_run/runUsingApt.rego
+++ b/pkg/policies/opa/rego/docker/docker_run/runUsingApt.rego
@@ -3,5 +3,5 @@ package accurics
 {{.prefix}}{{.name}}{{.suffix}}[cmd.id]{
 	cmd := input.docker_RUN[_]
     config := cmd.config
-    contains(config, "apt")
+    regex.match(`(^|\W)apt\s`, config)
 }

--- a/pkg/policies/opa/rego/docker/docker_run/runusingcd.rego
+++ b/pkg/policies/opa/rego/docker/docker_run/runusingcd.rego
@@ -3,5 +3,5 @@ package accurics
 {{.prefix}}{{.name}}{{.suffix}}[dockerRun]{
 	dockerRun := input.docker_RUN[_]
     config := dockerRun.config
-    contains(config, "cd")
+    regex.match(`^cd\s`, config)
 }


### PR DESCRIPTION
Alerting when a RUN command simply contains "apt" or "cd" substrings leads to abundant false positives.

Example: https://github.com/tenable/terrascan/discussions/977
